### PR TITLE
fix: --status showing devices again

### DIFF
--- a/fzf-bluetooth
+++ b/fzf-bluetooth
@@ -173,7 +173,7 @@ print_status() {
     if power_on; then
         printf ''
 
-        mapfile -t paired_devices < <(bluetoothctl paired-devices | grep Device | cut -d ' ' -f 2)
+        mapfile -t paired_devices < <(bluetoothctl devices | grep Device | cut -d ' ' -f 2)
         counter=0
 
         for device in "${paired_devices[@]}"; do


### PR DESCRIPTION
seems menu have changed. I'm on 
`Linux rechenknecht 6.1.11-1-MANJARO #1 SMP PREEMPT_DYNAMIC Thu Feb  9 14:03:23 UTC 2023 x86_64 GNU/Linux`